### PR TITLE
Switched openjdk-alpine to eclipse-temurin:21-jre-alpine in DockerFil…

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-alpine AS build
+FROM eclipse-temurin:21-jre-alpine AS build
 WORKDIR /app
 COPY .mvn/ .mvn/
 COPY mvnw pom.xml ./
@@ -6,7 +6,7 @@ RUN ./mvnw dependency:go-offline -B
 COPY src ./src
 RUN ./mvnw clean package -DskipTests
 
-FROM openjdk:21-jdk-alpine
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 EXPOSE 8080
 COPY --from=build /app/target/deeroot-shop-0.0.1-SNAPSHOT.jar app.jar


### PR DESCRIPTION
…e due to deployment issues.